### PR TITLE
Add link utilities, copy support, and statistics dashboard

### DIFF
--- a/taskfocus.py
+++ b/taskfocus.py
@@ -19,11 +19,16 @@
 #   • All comments and strings are in English, as requested.
 #   • You can customize defaults in the CONFIG section.
 
+import itertools
 import json
 import os
 import sys
 import re
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
+
+import webbrowser
+from collections import defaultdict
+from urllib.parse import urlparse
 
 import tkinter as tk
 from tkinter import messagebox
@@ -39,6 +44,17 @@ try:
 except ImportError:
     print("Please install tkcalendar: pip install tkcalendar")
     raise
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    from matplotlib import pyplot as plt
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+    plt = None
+    FigureCanvasTkAgg = None
 
 # -------------------------------
 # CONFIG
@@ -156,13 +172,248 @@ def sort_key(task: dict):
     return (pr, dl, sd, created)
 
 
+def create_dark_date_entry(master) -> DateEntry:
+    """Return a DateEntry that matches the dark UI theme."""
+    entry = DateEntry(
+        master,
+        date_pattern='yyyy-mm-dd',
+        font=("Segoe UI", 14),
+        background="#1E1B4B",
+        foreground="#E5E7EB",
+        borderwidth=0,
+        width=16,
+        selectbackground="#8B5CF6",
+        selectforeground="#F9FAFB",
+        fieldbackground="#111827",
+        normalbackground="#1E1B4B",
+        normalforeground="#F9FAFB",
+        headersbackground="#312E81",
+        headersforeground="#E5E7EB",
+    )
+    try:
+        entry.configure(
+            insertbackground="#F9FAFB",
+            disabledbackground="#1F2937",
+            disabledforeground="#6B7280",
+        )
+    except (tk.TclError, AttributeError):
+        # Some tkcalendar builds forward unknown options to the popup Calendar
+        # widget, which does not accept these entry-specific attributes. Fail
+        # quietly so the dark styling still applies wherever supported.
+        pass
+    try:
+        cal = entry._top_cal  # type: ignore[attr-defined]
+        cal.configure(
+            background="#111827",
+            foreground="#F9FAFB",
+            selectbackground="#8B5CF6",
+            selectforeground="#F9FAFB",
+            headersbackground="#312E81",
+            headersforeground="#E5E7EB",
+            weekendbackground="#1E1B4B",
+            weekendforeground="#F3F4F6",
+            othermonthbackground="#111827",
+            othermonthforeground="#6B7280",
+            disableddaybackground="#1F2937",
+            disableddayforeground="#6B7280",
+        )
+        try:
+            cal.configure(font=("Segoe UI", 12))
+        except tk.TclError:
+            pass
+    except Exception:
+        # Fallback quietly if tkcalendar internals change.
+        pass
+    return entry
+
+
+URL_REGEX = re.compile(r'https?://[^\s<>"\']+')
+TRAILING_URL_CHARS = ")]},.;'\":>"
+
+
+def _normalize_url(raw: str) -> str | None:
+    url = raw.strip()
+    while url and url[-1] in TRAILING_URL_CHARS:
+        url = url[:-1]
+    if not url:
+        return None
+    if url.startswith("www."):
+        url = "https://" + url
+    if not url.lower().startswith(("http://", "https://")):
+        return None
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return url
+
+
+def gather_task_links(task: dict) -> list[str]:
+    texts = [task.get("description", "")]
+    for session in task.get("sessions", []):
+        texts.append(session.get("note", ""))
+    seen: set[str] = set()
+    links: list[str] = []
+    for text in texts:
+        if not text:
+            continue
+        for match in URL_REGEX.findall(text):
+            url = _normalize_url(match)
+            if url and url.lower() not in seen:
+                seen.add(url.lower())
+                links.append(url)
+    return links
+
+
+def parse_session_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(value)
+    except Exception:
+        return None
+
+
+def iso_to_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).date()
+    except Exception:
+        return None
+
+
+def make_textbox_copyable(textbox: ctk.CTkTextbox):
+    textbox.configure(state="disabled", wrap="word")
+
+    def enable():
+        textbox.configure(state="normal")
+
+    def disable():
+        textbox.configure(state="disabled")
+
+    def copy_selection() -> None:
+        enable()
+        try:
+            text = textbox.get("sel.first", "sel.last")
+        except tk.TclError:
+            text = ""
+        if text:
+            textbox.clipboard_clear()
+            textbox.clipboard_append(text)
+        textbox.after_idle(disable)
+
+    def select_all():
+        enable()
+        textbox.tag_add("sel", "1.0", "end-1c")
+        textbox.after_idle(disable)
+
+    def block_edit(event):
+        modifiers = event.state
+        if modifiers & (0x4 | 0x20000 | 0x100000):  # Control or Command
+            key = event.keysym.lower()
+            if key == "c":
+                copy_selection()
+            elif key == "a":
+                select_all()
+        return "break"
+
+    def on_mouse_down(_event):
+        enable()
+
+    def on_mouse_up(_event):
+        textbox.after_idle(disable)
+
+    def show_menu(event):
+        enable()
+        menu = tk.Menu(textbox, tearoff=0)
+        menu.add_command(label="Copy", command=copy_selection)
+        menu.add_command(label="Select All", command=select_all)
+        try:
+            menu.tk_popup(event.x_root, event.y_root)
+            menu.grab_release()
+        finally:
+            textbox.after_idle(disable)
+        return "break"
+
+    def on_copy(_event=None):
+        copy_selection()
+        return "break"
+
+    def on_select_all(_event=None):
+        select_all()
+        return "break"
+
+    textbox.bind("<Key>", block_edit)
+    textbox.bind("<Button-1>", on_mouse_down)
+    textbox.bind("<B1-Motion>", lambda _event: None)
+    textbox.bind("<ButtonRelease-1>", on_mouse_up)
+    textbox.bind("<FocusOut>", lambda _event: disable())
+    textbox.bind("<Control-c>", on_copy)
+    textbox.bind("<Control-a>", on_select_all)
+    textbox.bind("<Command-c>", on_copy)
+    textbox.bind("<Command-a>", on_select_all)
+    textbox.bind("<Button-3>", show_menu)
+    textbox.bind("<Button-2>", show_menu)
+
+
+def shorten_url_display(url: str, max_length: int = 36) -> str:
+    parsed = urlparse(url)
+    display = url
+    if parsed.netloc:
+        display = parsed.netloc + parsed.path
+    if len(display) > max_length:
+        return display[: max_length - 1] + "…"
+    return display
+
+
+def parse_minutes_input(raw: str) -> int:
+    """Parse flexible minute input supporting m, h, and H:MM formats."""
+    if raw is None:
+        raise ValueError("No time entered")
+    value = raw.strip().lower().replace(" ", "")
+    if not value:
+        raise ValueError("No time entered")
+
+    try:
+        if ":" in value:
+            hours_str, mins_str = value.split(":", 1)
+            hours = int(hours_str.strip() or 0)
+            minutes = int(mins_str.strip() or 0)
+            total = hours * 60 + minutes
+        elif "h" in value:
+            hours_part, minutes_part = value.split("h", 1)
+            hours = float(hours_part) if hours_part else 0.0
+            minutes_text = minutes_part.replace("m", "") if minutes_part else ""
+            minutes = float(minutes_text) if minutes_text else 0.0
+            total = int(round(hours * 60 + minutes))
+        else:
+            suffix = value[-1] if value[-1].isalpha() else ""
+            number_part = value[:-1] if suffix else value
+            amount = float(number_part)
+            if suffix == "h":
+                total = int(round(amount * 60))
+            else:
+                total = int(round(amount))
+    except (TypeError, ValueError):
+        raise ValueError("Invalid time format") from None
+
+    if total <= 0:
+        raise ValueError("Time must be greater than zero")
+    return total
+
+
 # -------------------------------
 # Storage
 # -------------------------------
 class TaskStore:
     def __init__(self, path):
         self.path = path
-        self.data = {"tasks": [], "meta": {"last_focus_date": None}}
+        self.data = {"tasks": [], "meta": {"last_focus_date": None, "people": []}}
         self.load()
 
     def load(self):
@@ -174,10 +425,16 @@ class TaskStore:
                 self.data = json.load(f)
             # Backward compatibility
             if "meta" not in self.data:
-                self.data["meta"] = {"last_focus_date": None}
+                self.data["meta"] = {"last_focus_date": None, "people": []}
+            if "people" not in self.data.get("meta", {}):
+                self.data["meta"]["people"] = []
+            # Ensure defaults on old tasks
+            for task in self.data.get("tasks", []):
+                self._ensure_task_defaults(task)
+                self.register_people(task.get("who_asked"), task.get("assignee"))
         except Exception:
             # Create fresh if corrupted
-            self.data = {"tasks": [], "meta": {"last_focus_date": None}}
+            self.data = {"tasks": [], "meta": {"last_focus_date": None, "people": []}}
             self.save()
 
     def save(self):
@@ -186,6 +443,14 @@ class TaskStore:
             json.dump(self.data, f, indent=2, ensure_ascii=False)
 
     # --- Task operations ---
+    def _ensure_task_defaults(self, task: dict):
+        task.setdefault("description", "")
+        task.setdefault("assignee", "")
+        task.setdefault("time_spent_minutes", 0)
+        task.setdefault("sessions", [])
+        task.setdefault("completed_at", None)
+        return task
+
     def _next_id(self) -> int:
         if not self.data["tasks"]:
             return 1
@@ -202,7 +467,9 @@ class TaskStore:
         task.setdefault("status", "open")
         task.setdefault("focus", False)
         task.setdefault("created_at", datetime.now().isoformat(timespec="seconds"))
-        self.data["tasks"].append(task)
+        task.setdefault("completed_at", None)
+        self.data["tasks"].append(self._ensure_task_defaults(task))
+        self.register_people(task.get("who_asked"), task.get("assignee"))
         self.save()
         return task
 
@@ -210,6 +477,8 @@ class TaskStore:
         for t in self.data["tasks"]:
             if t.get("id") == task_id:
                 t.update(updates)
+                self._ensure_task_defaults(t)
+                self.register_people(t.get("who_asked"), t.get("assignee"))
                 self.save()
                 return t
         return None
@@ -223,6 +492,47 @@ class TaskStore:
         if status in STATUSES:
             tasks = [t for t in tasks if t.get("status") == status]
         return tasks
+
+    def register_people(self, *names: str | None):
+        names_clean = [n.strip() for n in names if n and n.strip()]
+        if not names_clean:
+            return
+        current = set(self.data.get("meta", {}).get("people", []))
+        updated = False
+        for name in names_clean:
+            if name not in current:
+                current.add(name)
+                updated = True
+        if updated:
+            self.data["meta"]["people"] = sorted(current)
+
+    def get_people(self) -> list[str]:
+        return list(self.data.get("meta", {}).get("people", []))
+
+    def append_session(self, task_id: int, minutes: int, note: str):
+        for t in self.data.get("tasks", []):
+            if t.get("id") == task_id:
+                self._ensure_task_defaults(t)
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+                session_entry = {
+                    "timestamp": timestamp,
+                    "minutes": minutes,
+                    "note": note,
+                }
+                t["sessions"].append(session_entry)
+                t["time_spent_minutes"] = int(t.get("time_spent_minutes", 0)) + int(minutes)
+                addition = f"[{timestamp}] ({minutes} min)"
+                if note:
+                    addition += f" {note}"
+                existing = t.get("description", "").rstrip()
+                if existing:
+                    new_desc = existing + "\n" + addition
+                else:
+                    new_desc = addition
+                t["description"] = new_desc
+                self.save()
+                return session_entry
+        return None
 
     def eligible_today(self):
         today = date.today()
@@ -254,24 +564,40 @@ class TaskStore:
 # GUI Components
 # -------------------------------
 class TaskCard(ctk.CTkFrame):
-    def __init__(self, master, task: dict, on_edit, on_done_toggle, on_focus_toggle):
+    def __init__(
+        self,
+        master,
+        task: dict,
+        on_edit,
+        on_done_toggle,
+        on_focus_toggle,
+        on_start_timer,
+        on_log_time,
+    ):
         super().__init__(master)
         self.task = task
         self.on_edit = on_edit
         self.on_done_toggle = on_done_toggle
         self.on_focus_toggle = on_focus_toggle
-
-        self.configure(padx=12, pady=12)
+        self.on_start_timer = on_start_timer
+        self.on_log_time = on_log_time
+        self._layout_mode: str | None = None
 
         # Left labels container
-        left = ctk.CTkFrame(self, fg_color="transparent")
-        left.grid(row=0, column=0, sticky="w")
+        self.left_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.left_frame.grid(row=0, column=0, sticky="ew", padx=(12, 6), pady=12)
 
-        title_row = ctk.CTkFrame(left, fg_color="transparent")
-        title_row.pack(anchor="w")
+        title_row = ctk.CTkFrame(self.left_frame, fg_color="transparent")
+        title_row.pack(anchor="w", fill="x")
 
         focus_prefix = "⭐ " if task.get("focus") else ""
-        self.title_label = ctk.CTkLabel(title_row, text=f"{focus_prefix}{task.get('title','(no title)')}", font=("Segoe UI", 16, "bold"))
+        self.title_label = ctk.CTkLabel(
+            title_row,
+            text=f"{focus_prefix}{task.get('title','(no title)')}",
+            font=("Segoe UI", 16, "bold"),
+            justify="left",
+            anchor="w",
+        )
         self.title_label.pack(side="left", padx=(0, 6))
 
         # Priority badge
@@ -279,10 +605,16 @@ class TaskCard(ctk.CTkFrame):
         pr_color = {
             "High": "#F97316",  # orange
             "Medium": "#A78BFA",  # purple-light
-            "Low": "#64748B"     # slate
+            "Low": "#64748B",    # slate
         }.get(pr, "#A78BFA")
-        pr_badge = ctk.CTkLabel(title_row, text=pr, fg_color=pr_color, text_color="#000000", corner_radius=8, padx=8, pady=2)
-        pr_badge.pack(side="left")
+        pr_badge = ctk.CTkLabel(
+            title_row,
+            text=f" {pr} ",
+            fg_color=pr_color,
+            text_color="#000000",
+            corner_radius=8,
+        )
+        pr_badge.pack(side="left", pady=2)
 
         # Meta line
         meta = []
@@ -292,9 +624,19 @@ class TaskCard(ctk.CTkFrame):
         who = task.get("who_asked")
         if who:
             meta.append(f"Asked by: {who}")
+        assignee = task.get("assignee")
+        if assignee:
+            meta.append(f"Assignee: {assignee}")
+        minutes = int(task.get("time_spent_minutes", 0) or 0)
+        if minutes:
+            hours, mins = divmod(minutes, 60)
+            if hours:
+                time_text = f"{hours}h {mins}m" if mins else f"{hours}h"
+            else:
+                time_text = f"{mins}m"
+            meta.append(f"Time spent: {time_text}")
         sd = task.get("start_date") or "—"
         dl = task.get("deadline") or "—"
-        # Overdue visual hint
         overdue = False
         if task.get("status") == "open" and parse_date(task.get("deadline", "")):
             if parse_date(task.get("deadline")) < date.today():
@@ -302,35 +644,201 @@ class TaskCard(ctk.CTkFrame):
         dl_text = f"Due: {dl}"
         if overdue:
             dl_text += "  (OVERDUE)"
-        meta_line = ctk.CTkLabel(left, text=f"{ ' | '.join(meta) }\nStart: {sd} | {dl_text}", justify="left")
-        meta_line.pack(anchor="w", pady=(6, 0))
+        top_line = " | ".join(meta)
+        if top_line:
+            meta_text = f"{top_line}\nStart: {sd} | {dl_text}"
+        else:
+            meta_text = f"Start: {sd} | {dl_text}"
+        self.meta_line = ctk.CTkLabel(self.left_frame, text=meta_text, justify="left", anchor="w")
+        self.meta_line.pack(anchor="w", pady=(6, 0))
+
+        desc_text = (task.get("description") or "").strip()
+        self.desc_box: ctk.CTkTextbox | None = None
+        if desc_text:
+            height = self._estimate_text_height(desc_text)
+            self.desc_label = ctk.CTkLabel(
+                self.left_frame,
+                text="Description",
+                anchor="w",
+                justify="left",
+                font=("Segoe UI", 13, "bold"),
+            )
+            self.desc_label.pack(anchor="w", pady=(8, 2))
+            self.desc_box = ctk.CTkTextbox(self.left_frame, height=height)
+            self.desc_box.pack(fill="x")
+            self.desc_box.insert("1.0", desc_text)
+            make_textbox_copyable(self.desc_box)
+
+        self.links = gather_task_links(task)
+        self.links_frame: ctk.CTkFrame | None = None
+        if self.links:
+            self.links_label = ctk.CTkLabel(
+                self.left_frame,
+                text=f"Links ({len(self.links)})",
+                anchor="w",
+                justify="left",
+            )
+            self.links_label.pack(anchor="w", pady=(8, 2))
+            self.links_frame = ctk.CTkFrame(self.left_frame, fg_color="transparent")
+            self.links_frame.pack(fill="x", pady=(0, 4))
+            for url in self.links:
+                btn = ctk.CTkButton(
+                    self.links_frame,
+                    text=f"🔗 {shorten_url_display(url)}",
+                    command=lambda url=url: self._open_link(url),
+                    height=32,
+                    width=0,
+                    fg_color="#1E3A8A",
+                    hover_color="#1D4ED8",
+                    text_color="#E0E7FF",
+                    font=("Segoe UI", 13),
+                    cursor="hand2",
+                )
+                btn.pack(fill="x", pady=2)
 
         # Right buttons
-        btns = ctk.CTkFrame(self, fg_color="transparent")
-        btns.grid(row=0, column=1, sticky="e")
+        self.btns_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.btns_frame.grid(row=0, column=1, sticky="e", padx=(6, 12), pady=12)
 
-        focus_text = "Unfocus" if task.get("focus") else "Focus ⭐"
-        self.focus_btn = ctk.CTkButton(btns, text=focus_text, command=lambda: self.on_focus_toggle(task))
-        self.focus_btn.pack(side="left", padx=6)
+        focus_active = bool(task.get("focus"))
+        focus_icon = "★" if focus_active else "☆"
+        self.focus_btn = self._make_button(
+            focus_icon,
+            lambda: self.on_focus_toggle(task),
+            width=48,
+        )
+        if focus_active:
+            self.focus_btn.configure(
+                fg_color="#3730A3",
+                hover_color="#312E81",
+                text_color="#FACC15",
+            )
+        else:
+            self.focus_btn.configure(
+                fg_color="#FACC15",
+                hover_color="#EAB308",
+                text_color="#111827",
+            )
 
-        self.edit_btn = ctk.CTkButton(btns, text="Edit", command=lambda: self.on_edit(task))
-        self.edit_btn.pack(side="left", padx=6)
+        self.timer_btn = self._make_button(
+            "Start work",
+            lambda: self.on_start_timer(task),
+            width=114,
+        )
+        self.log_btn = self._make_button(
+            "Log time",
+            lambda: self.on_log_time(task),
+            width=102,
+        )
+        self.edit_btn = self._make_button(
+            "Edit",
+            lambda: self.on_edit(task),
+            width=76,
+            fg_color="#374151",
+            hover_color="#4B5563",
+        )
 
-        done_text = "Mark Open" if task.get("status") == "done" else "Mark Done"
-        self.done_btn = ctk.CTkButton(btns, text=done_text, command=lambda: self.on_done_toggle(task))
-        self.done_btn.pack(side="left", padx=6)
+        done_active = task.get("status") == "done"
+        done_text = "Reopen" if done_active else "Done"
+        done_fg = "#4B5563" if done_active else "#22C55E"
+        done_hover = "#6B7280" if done_active else "#16A34A"
+        self.done_btn = self._make_button(
+            done_text,
+            lambda: self.on_done_toggle(task),
+            width=92,
+            fg_color=done_fg,
+            hover_color=done_hover,
+        )
+
+        if not done_active:
+            self.done_btn.configure(text_color="#0B1120")
+
+        self._buttons = [
+            self.focus_btn,
+            self.timer_btn,
+            self.log_btn,
+            self.edit_btn,
+            self.done_btn,
+        ]
+        self._arrange_buttons("inline")
 
         self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(0, weight=1)
+
+        self.bind("<Configure>", self._on_configure)
+
+    def _open_link(self, url: str):
+        webbrowser.open(url)
+
+    def _estimate_text_height(self, text: str) -> int:
+        lines = text.count("\n") + 1
+        extra = max(len(text) // 120, 0)
+        total_lines = lines + extra
+        return max(80, min(240, total_lines * 22))
+
+    def _make_button(
+        self,
+        text: str,
+        command,
+        *,
+        width: int,
+        fg_color: str = "#4C1D95",
+        hover_color: str = "#5B21B6",
+        text_color: str = "#F9FAFB",
+    ) -> ctk.CTkButton:
+        return ctk.CTkButton(
+            self.btns_frame,
+            text=text,
+            command=command,
+            width=width,
+            height=34,
+            fg_color=fg_color,
+            hover_color=hover_color,
+            text_color=text_color,
+            font=("Segoe UI", 13),
+            corner_radius=6,
+        )
+
+    def _arrange_buttons(self, mode: str):
+        for btn in self._buttons:
+            btn.pack_forget()
+        if mode == "stacked":
+            for btn in self._buttons:
+                btn.pack(fill="x", padx=4, pady=4)
+        else:
+            for btn in self._buttons:
+                btn.pack(side="left", padx=4)
+        self._layout_mode = mode
+
+    def _on_configure(self, _event=None):
+        width = max(self.winfo_width(), 1)
+        wrap = max(width - 220, 260)
+        self.title_label.configure(wraplength=wrap)
+        self.meta_line.configure(wraplength=wrap)
+
+        mode = "stacked" if width < 1100 else "inline"
+        if mode != self._layout_mode:
+            if mode == "stacked":
+                self.left_frame.grid_configure(row=0, column=0, columnspan=2, sticky="ew", padx=(12, 12), pady=(12, 6))
+                self.btns_frame.grid_configure(row=1, column=0, columnspan=2, sticky="ew", padx=(12, 12), pady=(0, 12))
+                self._arrange_buttons("stacked")
+            else:
+                self.left_frame.grid_configure(row=0, column=0, columnspan=1, sticky="ew", padx=(12, 6), pady=12)
+                self.btns_frame.grid_configure(row=0, column=1, columnspan=1, sticky="e", padx=(6, 12), pady=12)
+                self._arrange_buttons("inline")
 
 
 class TaskEditor(ctk.CTkToplevel):
-    def __init__(self, master, task: dict, on_save):
+    def __init__(self, master, task: dict, on_save, people: list[str]):
         super().__init__(master)
         self.title("Edit Task")
-        self.geometry("520x480")
-        self.resizable(False, False)
+        self.geometry("620x640")
+        self.resizable(True, True)
         self.task = task.copy()
         self.on_save = on_save
+        initial_people = {p for p in people if p}
+        initial_people.update({task.get("who_asked", ""), task.get("assignee", "")})
+        self.people = sorted({p for p in initial_people if p})
 
         container = ctk.CTkFrame(self)
         container.pack(fill="both", expand=True, padx=16, pady=16)
@@ -352,43 +860,86 @@ class TaskEditor(ctk.CTkToplevel):
         self.pr_menu.grid(row=3, column=1, sticky="ew", pady=(0,8))
         self.pr_menu.set(task.get("priority", PRIORITIES[1]))
 
-        # Who asked
+        # Who asked & Assignee
         ctk.CTkLabel(container, text="Who asked").grid(row=4, column=0, sticky="w")
-        self.who_entry = ctk.CTkEntry(container)
-        self.who_entry.grid(row=5, column=0, columnspan=2, sticky="ew", pady=(0,8))
-        self.who_entry.insert(0, task.get("who_asked", ""))
+        self.who_entry = ctk.CTkComboBox(container, values=self._people_values(), justify="left")
+        self.who_entry.grid(row=5, column=0, sticky="ew", pady=(0,8))
+        self.who_entry.set(task.get("who_asked", ""))
+
+        ctk.CTkLabel(container, text="Assignee").grid(row=4, column=1, sticky="w")
+        self.assignee_entry = ctk.CTkComboBox(container, values=self._people_values(), justify="left")
+        self.assignee_entry.grid(row=5, column=1, sticky="ew", pady=(0,8))
+        self.assignee_entry.set(task.get("assignee", ""))
 
         # Start & Deadline (tkcalendar)
         ctk.CTkLabel(container, text="Start Date").grid(row=6, column=0, sticky="w")
-        self.start_date = DateEntry(container, date_pattern='yyyy-mm-dd')
+        self.start_date = create_dark_date_entry(container)
         self.start_date.grid(row=7, column=0, sticky="ew", pady=(0,8))
         sd = parse_date(task.get("start_date", "")) or date.today()
         self.start_date.set_date(sd)
 
         ctk.CTkLabel(container, text="Deadline").grid(row=6, column=1, sticky="w")
-        self.deadline = DateEntry(container, date_pattern='yyyy-mm-dd')
+        self.deadline = create_dark_date_entry(container)
         self.deadline.grid(row=7, column=1, sticky="ew", pady=(0,8))
         dl = parse_date(task.get("deadline", "")) or date.today()
         self.deadline.set_date(dl)
 
+        # Description
+        ctk.CTkLabel(container, text="Description").grid(row=8, column=0, columnspan=2, sticky="w")
+        self.description_box = ctk.CTkTextbox(container, height=160)
+        self.description_box.grid(row=9, column=0, columnspan=2, sticky="nsew", pady=(0,8))
+        self.description_box.insert("1.0", task.get("description", ""))
+
+        # Session history (read-only)
+        ctk.CTkLabel(container, text="Session history").grid(row=10, column=0, columnspan=2, sticky="w")
+        self.history_box = ctk.CTkTextbox(container, height=140)
+        self.history_box.grid(row=11, column=0, columnspan=2, sticky="nsew", pady=(0,8))
+        self.history_box.insert("1.0", self._format_sessions(task))
+        make_textbox_copyable(self.history_box)
+
+        next_row = 12
+        self.links = gather_task_links(task)
+        if self.links:
+            ctk.CTkLabel(container, text=f"Links ({len(self.links)})").grid(row=next_row, column=0, columnspan=2, sticky="w")
+            next_row += 1
+            links_frame = ctk.CTkFrame(container, fg_color="transparent")
+            links_frame.grid(row=next_row, column=0, columnspan=2, sticky="ew", pady=(0,8))
+            for url in self.links:
+                btn = ctk.CTkButton(
+                    links_frame,
+                    text=f"🔗 {shorten_url_display(url)}",
+                    command=lambda url=url: webbrowser.open(url),
+                    height=30,
+                    width=0,
+                    fg_color="#1E3A8A",
+                    hover_color="#1D4ED8",
+                    text_color="#E0E7FF",
+                    font=("Segoe UI", 13),
+                    cursor="hand2",
+                )
+                btn.pack(fill="x", pady=2)
+            next_row += 1
+
         # Status + Focus
-        ctk.CTkLabel(container, text="Status").grid(row=8, column=0, sticky="w")
+        ctk.CTkLabel(container, text="Status").grid(row=next_row, column=0, sticky="w")
         self.status_menu = ctk.CTkOptionMenu(container, values=STATUSES)
-        self.status_menu.grid(row=9, column=0, sticky="ew", pady=(0,8))
+        self.status_menu.grid(row=next_row + 1, column=0, sticky="ew", pady=(0,8))
         self.status_menu.set(task.get("status", "open"))
 
         self.focus_var = tk.BooleanVar(value=task.get("focus", False))
         self.focus_chk = ctk.CTkCheckBox(container, text="Focus for Today", variable=self.focus_var)
-        self.focus_chk.grid(row=9, column=1, sticky="w")
+        self.focus_chk.grid(row=next_row + 1, column=1, sticky="w")
 
         # Buttons
         btns = ctk.CTkFrame(container, fg_color="transparent")
-        btns.grid(row=10, column=0, columnspan=2, sticky="e", pady=(8,0))
+        btns.grid(row=next_row + 2, column=0, columnspan=2, sticky="e", pady=(8,0))
         ctk.CTkButton(btns, text="Cancel", command=self.destroy).pack(side="right", padx=6)
         ctk.CTkButton(btns, text="Save", command=self._save).pack(side="right", padx=6)
 
         container.columnconfigure(0, weight=1)
         container.columnconfigure(1, weight=1)
+        container.rowconfigure(9, weight=1)
+        container.rowconfigure(11, weight=1)
 
     def _save(self):
         updated = {
@@ -396,16 +947,224 @@ class TaskEditor(ctk.CTkToplevel):
             "type": self.type_menu.get(),
             "priority": self.pr_menu.get(),
             "who_asked": self.who_entry.get().strip(),
+            "assignee": self.assignee_entry.get().strip(),
             "start_date": self.start_date.get_date().strftime('%Y-%m-%d'),
             "deadline": self.deadline.get_date().strftime('%Y-%m-%d'),
             "status": self.status_menu.get(),
             "focus": bool(self.focus_var.get()),
+            "description": self.description_box.get("1.0", tk.END).strip(),
         }
         if not updated["title"]:
             messagebox.showwarning("Validation", "Title cannot be empty")
             return
         self.on_save(updated)
         self.destroy()
+
+    def _people_values(self) -> list[str]:
+        return [""] + self.people
+
+    def _format_sessions(self, task: dict) -> str:
+        sessions = task.get("sessions") or []
+        if not sessions:
+            return "No sessions recorded yet."
+        lines = []
+        for session in sessions:
+            ts = session.get("timestamp", "?")
+            minutes = session.get("minutes", 0)
+            note = session.get("note", "")
+            line = f"{ts} — {minutes} min"
+            if note:
+                line += f": {note}"
+            lines.append(line)
+        return "\n".join(lines)
+
+
+class SessionLogDialog(ctk.CTkToplevel):
+    def __init__(
+        self,
+        master,
+        *,
+        title: str,
+        preset_minutes: int | None = None,
+        allow_minutes_edit: bool = True,
+        prompt: str,
+    ):
+        super().__init__(master)
+        self.title(title)
+        self.geometry("540x440")
+        self.minsize(480, 360)
+        self.transient(master)
+        self.grab_set()
+        self.result: tuple[int, str] | None = None
+
+        container = ctk.CTkFrame(self)
+        container.pack(fill="both", expand=True, padx=18, pady=18)
+
+        time_label = ctk.CTkLabel(container, text="Minutes spent", font=("Segoe UI", 14, "bold"))
+        time_label.pack(anchor="w")
+
+        self.minutes_var = tk.StringVar()
+        if preset_minutes is not None:
+            self.minutes_var.set(str(preset_minutes))
+        self.error_label = ctk.CTkLabel(container, text="", text_color="#F87171")
+        self.minutes_entry = ctk.CTkEntry(container, textvariable=self.minutes_var, font=("Segoe UI", 14))
+        self.minutes_entry.pack(fill="x", pady=(4, 12))
+        if not allow_minutes_edit and preset_minutes is not None:
+            self.minutes_entry.configure(state="disabled")
+        else:
+            self.minutes_var.trace_add("write", lambda *_: self.error_label.configure(text=""))
+
+        ctk.CTkLabel(
+            container,
+            text=prompt,
+            justify="left",
+            anchor="w",
+        ).pack(anchor="w")
+
+        self.note_box = ctk.CTkTextbox(container, height=220)
+        self.note_box.configure(font=("Segoe UI", 13), wrap="word")
+        self.note_box.pack(fill="both", expand=True, pady=(8, 12))
+
+        self.error_label.pack(anchor="w", pady=(0, 8))
+
+        btns = ctk.CTkFrame(container, fg_color="transparent")
+        btns.pack(fill="x")
+        ctk.CTkButton(btns, text="Cancel", command=self._cancel).pack(side="right", padx=6)
+        ctk.CTkButton(btns, text="Save", command=self._submit).pack(side="right", padx=6)
+
+        if allow_minutes_edit and preset_minutes is None:
+            self.minutes_entry.focus_set()
+        else:
+            self.note_box.focus_set()
+
+        self.bind("<Return>", self._submit_event)
+        self.bind("<Escape>", self._cancel_event)
+        self.protocol("WM_DELETE_WINDOW", self._cancel)
+
+    def show(self) -> tuple[int, str] | None:
+        self.wait_window()
+        return self.result
+
+    def _submit_event(self, _event=None):
+        self._submit()
+
+    def _cancel_event(self, _event=None):
+        self._cancel()
+
+    def _submit(self):
+        try:
+            minutes = parse_minutes_input(self.minutes_var.get())
+        except ValueError as exc:
+            self.error_label.configure(text=str(exc))
+            return
+        note = self.note_box.get("1.0", tk.END).strip()
+        self.result = (minutes, note)
+        self.destroy()
+
+    def _cancel(self):
+        self.result = None
+        self.destroy()
+
+
+class PomodoroWindow(ctk.CTkToplevel):
+    def __init__(self, master, task: dict, on_complete, on_close):
+        super().__init__(master)
+        self.title(f"Timer — {task.get('title', 'Task')}")
+        self.geometry("360x260")
+        self.resizable(False, False)
+        self.on_complete = on_complete
+        self.on_close = on_close
+        self._after_id = None
+        self._timer_running = False
+        self._total_minutes = 0
+        self._remaining_seconds = 0
+
+        self.label = ctk.CTkLabel(self, text=f"Task: {task.get('title', '(no title)')}", wraplength=320)
+        self.label.pack(pady=(16, 8), padx=16)
+
+        entry_frame = ctk.CTkFrame(self, fg_color="transparent")
+        entry_frame.pack(pady=(0, 12))
+        ctk.CTkLabel(entry_frame, text="Minutes to focus:").pack(side="left", padx=(0, 8))
+        self.minutes_var = tk.StringVar(value="25")
+        self.minutes_entry = ctk.CTkEntry(entry_frame, textvariable=self.minutes_var, width=80)
+        self.minutes_entry.pack(side="left")
+
+        self.timer_label = ctk.CTkLabel(self, text="00:00", font=("Segoe UI", 28, "bold"))
+        self.timer_label.pack(pady=(0, 12))
+
+        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
+        btn_frame.pack(pady=(0, 16))
+        self.start_btn = ctk.CTkButton(btn_frame, text="Start", command=self._start_timer)
+        self.start_btn.pack(side="left", padx=6)
+        self.stop_btn = ctk.CTkButton(btn_frame, text="Stop", command=self._stop_timer, state="disabled")
+        self.stop_btn.pack(side="left", padx=6)
+
+        self.protocol("WM_DELETE_WINDOW", self._on_close_request)
+
+    def _start_timer(self):
+        if self._timer_running:
+            return
+        try:
+            minutes = int(self.minutes_var.get())
+        except (TypeError, ValueError):
+            messagebox.showwarning("Timer", "Please enter a valid number of minutes.")
+            return
+        if minutes <= 0:
+            messagebox.showwarning("Timer", "Minutes must be greater than zero.")
+            return
+        self._total_minutes = minutes
+        self._remaining_seconds = minutes * 60
+        self._timer_running = True
+        self.start_btn.configure(state="disabled")
+        self.stop_btn.configure(state="normal")
+        self.minutes_entry.configure(state="disabled")
+        self._tick()
+
+    def _tick(self):
+        mins, secs = divmod(self._remaining_seconds, 60)
+        self.timer_label.configure(text=f"{mins:02d}:{secs:02d}")
+        if self._remaining_seconds <= 0:
+            self._finish_timer()
+            return
+        self._remaining_seconds -= 1
+        self._after_id = self.after(1000, self._tick)
+
+    def _finish_timer(self):
+        self._timer_running = False
+        if self._after_id:
+            self.after_cancel(self._after_id)
+            self._after_id = None
+        self.start_btn.configure(state="normal")
+        self.stop_btn.configure(state="disabled")
+        self.minutes_entry.configure(state="normal")
+        if self.on_complete:
+            self.on_complete(self._total_minutes)
+        self._cleanup_and_close()
+
+    def _stop_timer(self):
+        if self._after_id:
+            self.after_cancel(self._after_id)
+            self._after_id = None
+        self._timer_running = False
+        self.start_btn.configure(state="normal")
+        self.stop_btn.configure(state="disabled")
+        self.minutes_entry.configure(state="normal")
+        self._cleanup_and_close()
+
+    def _on_close_request(self):
+        if self._timer_running and not messagebox.askyesno("Stop timer?", "Timer is still running. Stop it?"):
+            return
+        self._stop_timer()
+
+    def _cleanup_and_close(self):
+        if self._after_id:
+            self.after_cancel(self._after_id)
+            self._after_id = None
+        self._timer_running = False
+        if self.on_close:
+            self.on_close()
+        if self.winfo_exists():
+            super().destroy()
 
 
 class FocusDialog(ctk.CTkToplevel):
@@ -457,7 +1216,15 @@ class TaskFocusApp(ctk.CTk):
         self.store = store
         self.title(APP_TITLE)
         self.geometry("1100x750")
-        self.minsize(950, 600)
+        self.minsize(720, 520)
+        self.people_options = self.store.get_people()
+        self.timer_window = None
+        self._layout_mode: str | None = None
+        self._widget_scale: float | None = None
+        self._responsive_after: str | None = None
+        self._pending_width: int | None = None
+
+        self.bind("<Configure>", self._on_window_configure)
 
         # App header
         header = ctk.CTkFrame(self)
@@ -471,12 +1238,14 @@ class TaskFocusApp(ctk.CTk):
         self.tabs.pack(fill="both", expand=True, padx=16, pady=(8,16))
         self.today_tab = self.tabs.add("Today's Tasks")
         self.all_tab = self.tabs.add("All Tasks")
+        self.stats_tab = self.tabs.add("Statistics")
         self.add_tab = self.tabs.add("Add Task")
         self.bulk_tab = self.tabs.add("Bulk Import")
 
         # Build each tab
         self._build_today_tab()
         self._build_all_tab()
+        self._build_stats_tab()
         self._build_add_tab()
         self._build_bulk_tab()
 
@@ -491,7 +1260,21 @@ class TaskFocusApp(ctk.CTk):
         # Start on Today's tab
         self.tabs.set("Today's Tasks")
 
+        # Apply responsive layout/sizing after widgets are drawn
+        self.after(150, self._initialize_responsive_layout)
+
     # ----------------------- UI Builders -----------------------
+    def _people_option_values(self) -> list[str]:
+        return [""] + sorted({p for p in self.people_options if p})
+
+    def _refresh_people_options(self):
+        self.people_options = self.store.get_people()
+        values = self._people_option_values()
+        if hasattr(self, "add_who"):
+            self.add_who.configure(values=values)
+        if hasattr(self, "add_assignee"):
+            self.add_assignee.configure(values=values)
+
     def _build_today_tab(self):
         # Top bar
         top = ctk.CTkFrame(self.today_tab)
@@ -518,63 +1301,221 @@ class TaskFocusApp(ctk.CTk):
         self.all_list = ctk.CTkScrollableFrame(self.all_tab)
         self.all_list.pack(fill="both", expand=True)
 
+    def _build_stats_tab(self):
+        if not MATPLOTLIB_AVAILABLE:
+            container = ctk.CTkFrame(self.stats_tab)
+            container.pack(fill="both", expand=True, padx=12, pady=12)
+            ctk.CTkLabel(
+                container,
+                text="Install matplotlib to view statistics charts (pip install matplotlib).",
+                wraplength=520,
+                justify="center",
+            ).pack(expand=True, pady=32)
+            self.stats_container = None
+            return
+
+        self.stats_container = ctk.CTkScrollableFrame(self.stats_tab)
+        self.stats_container.pack(fill="both", expand=True, padx=12, pady=12)
+
+        # Time spent chart section
+        self.time_section = ctk.CTkFrame(self.stats_container)
+        self.time_section.pack(fill="both", expand=True, pady=(0, 16))
+        ctk.CTkLabel(
+            self.time_section,
+            text="Time spent per task (last 7 days)",
+            font=("Segoe UI", 16, "bold"),
+        ).pack(anchor="w", padx=8, pady=(8, 4))
+        self.time_chart_holder = ctk.CTkFrame(self.time_section, fg_color="#111827")
+        self.time_chart_holder.pack(fill="both", expand=True, padx=8, pady=(0, 8))
+        self.time_canvas: FigureCanvasTkAgg | None = None
+
+        # Burn-down chart section
+        self.burn_section = ctk.CTkFrame(self.stats_container)
+        self.burn_section.pack(fill="both", expand=True, pady=(0, 16))
+        ctk.CTkLabel(
+            self.burn_section,
+            text="Task burn-down (last 7 days)",
+            font=("Segoe UI", 16, "bold"),
+        ).pack(anchor="w", padx=8, pady=(8, 4))
+        self.burn_chart_holder = ctk.CTkFrame(self.burn_section, fg_color="#111827")
+        self.burn_chart_holder.pack(fill="both", expand=True, padx=8, pady=(0, 8))
+        self.burn_canvas: FigureCanvasTkAgg | None = None
+
     def _build_add_tab(self):
         container = ctk.CTkFrame(self.add_tab)
         container.pack(fill="both", expand=True, padx=12, pady=12)
+        self.add_container = container
 
-        # Title
-        ctk.CTkLabel(container, text="Title").grid(row=0, column=0, sticky="w")
+        self.add_title_label = ctk.CTkLabel(container, text="Title")
         self.add_title = ctk.CTkEntry(container)
-        self.add_title.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(0,8))
 
-        # Type & Priority
-        ctk.CTkLabel(container, text="Type").grid(row=2, column=0, sticky="w")
+        self.add_type_label = ctk.CTkLabel(container, text="Type")
         self.add_type = ctk.CTkOptionMenu(container, values=TASK_TYPES)
-        self.add_type.grid(row=3, column=0, sticky="ew", pady=(0,8))
         self.add_type.set(TASK_TYPES[0])
 
-        ctk.CTkLabel(container, text="Priority").grid(row=2, column=1, sticky="w")
+        self.add_priority_label = ctk.CTkLabel(container, text="Priority")
         self.add_priority = ctk.CTkOptionMenu(container, values=PRIORITIES)
-        self.add_priority.grid(row=3, column=1, sticky="ew", pady=(0,8))
         self.add_priority.set(PRIORITIES[1])
 
-        # Who asked
-        ctk.CTkLabel(container, text="Who asked").grid(row=4, column=0, sticky="w")
-        self.add_who = ctk.CTkEntry(container)
-        self.add_who.grid(row=5, column=0, columnspan=2, sticky="ew", pady=(0,8))
+        self.add_who_label = ctk.CTkLabel(container, text="Who asked")
+        self.add_who = ctk.CTkComboBox(container, values=self._people_option_values(), justify="left")
+        self.add_who.set("")
 
-        # Dates
-        ctk.CTkLabel(container, text="Start Date").grid(row=6, column=0, sticky="w")
-        self.add_start = DateEntry(container, date_pattern='yyyy-mm-dd')
-        self.add_start.grid(row=7, column=0, sticky="ew", pady=(0,8))
+        self.add_assignee_label = ctk.CTkLabel(container, text="Assignee")
+        self.add_assignee = ctk.CTkComboBox(container, values=self._people_option_values(), justify="left")
+        self.add_assignee.set("")
+
+        self.add_start_label = ctk.CTkLabel(container, text="Start Date")
+        self.add_start = create_dark_date_entry(container)
         self.add_start.set_date(date.today())
 
-        ctk.CTkLabel(container, text="Deadline").grid(row=6, column=1, sticky="w")
-        self.add_deadline = DateEntry(container, date_pattern='yyyy-mm-dd')
-        self.add_deadline.grid(row=7, column=1, sticky="ew", pady=(0,8))
+        self.add_deadline_label = ctk.CTkLabel(container, text="Deadline")
+        self.add_deadline = create_dark_date_entry(container)
         self.add_deadline.set_date(date.today())
 
-        # Buttons
-        btns = ctk.CTkFrame(container, fg_color="transparent")
-        btns.grid(row=8, column=0, columnspan=2, sticky="e")
-        ctk.CTkButton(btns, text="Clear", command=self._clear_add_form).pack(side="left", padx=6)
-        ctk.CTkButton(btns, text="Add Task", command=self._add_task_from_form).pack(side="left", padx=6)
+        self.add_description_label = ctk.CTkLabel(container, text="Description")
+        self.add_description = ctk.CTkTextbox(container, height=160)
+
+        self.add_button_row = ctk.CTkFrame(container, fg_color="transparent")
+        ctk.CTkButton(self.add_button_row, text="Clear", command=self._clear_add_form).pack(side="left", padx=6)
+        ctk.CTkButton(self.add_button_row, text="Add Task", command=self._add_task_from_form).pack(side="left", padx=6)
 
         container.columnconfigure(0, weight=1)
         container.columnconfigure(1, weight=1)
 
+        self._layout_add_form("wide")
+
+    def _layout_add_form(self, mode: str):
+        container = self.add_container
+        widgets = [
+            self.add_title_label,
+            self.add_title,
+            self.add_type_label,
+            self.add_type,
+            self.add_priority_label,
+            self.add_priority,
+            self.add_who_label,
+            self.add_who,
+            self.add_assignee_label,
+            self.add_assignee,
+            self.add_start_label,
+            self.add_start,
+            self.add_deadline_label,
+            self.add_deadline,
+            self.add_description_label,
+            self.add_description,
+            self.add_button_row,
+        ]
+        for w in widgets:
+            w.grid_forget()
+
+        for idx in range(0, 20):
+            container.rowconfigure(idx, weight=0)
+
+        if mode == "narrow":
+            container.grid_columnconfigure(0, weight=1)
+            container.grid_columnconfigure(1, weight=0)
+            placements = [
+                (self.add_title_label, {"row": 0, "column": 0, "sticky": "w"}),
+                (self.add_title, {"row": 1, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_type_label, {"row": 2, "column": 0, "sticky": "w"}),
+                (self.add_type, {"row": 3, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_priority_label, {"row": 4, "column": 0, "sticky": "w"}),
+                (self.add_priority, {"row": 5, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_who_label, {"row": 6, "column": 0, "sticky": "w"}),
+                (self.add_who, {"row": 7, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_assignee_label, {"row": 8, "column": 0, "sticky": "w"}),
+                (self.add_assignee, {"row": 9, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_start_label, {"row": 10, "column": 0, "sticky": "w"}),
+                (self.add_start, {"row": 11, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_deadline_label, {"row": 12, "column": 0, "sticky": "w"}),
+                (self.add_deadline, {"row": 13, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_description_label, {"row": 14, "column": 0, "sticky": "w"}),
+                (self.add_description, {"row": 15, "column": 0, "sticky": "nsew", "pady": (0, 8)}),
+                (self.add_button_row, {"row": 16, "column": 0, "sticky": "e"}),
+            ]
+            target_row = 15
+        else:
+            container.grid_columnconfigure(0, weight=1)
+            container.grid_columnconfigure(1, weight=1)
+            placements = [
+                (self.add_title_label, {"row": 0, "column": 0, "columnspan": 2, "sticky": "w"}),
+                (self.add_title, {"row": 1, "column": 0, "columnspan": 2, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_type_label, {"row": 2, "column": 0, "sticky": "w"}),
+                (self.add_priority_label, {"row": 2, "column": 1, "sticky": "w"}),
+                (self.add_type, {"row": 3, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_priority, {"row": 3, "column": 1, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_who_label, {"row": 4, "column": 0, "sticky": "w"}),
+                (self.add_assignee_label, {"row": 4, "column": 1, "sticky": "w"}),
+                (self.add_who, {"row": 5, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_assignee, {"row": 5, "column": 1, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_start_label, {"row": 6, "column": 0, "sticky": "w"}),
+                (self.add_deadline_label, {"row": 6, "column": 1, "sticky": "w"}),
+                (self.add_start, {"row": 7, "column": 0, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_deadline, {"row": 7, "column": 1, "sticky": "ew", "pady": (0, 8)}),
+                (self.add_description_label, {"row": 8, "column": 0, "columnspan": 2, "sticky": "w"}),
+                (self.add_description, {"row": 9, "column": 0, "columnspan": 2, "sticky": "nsew", "pady": (0, 8)}),
+                (self.add_button_row, {"row": 10, "column": 0, "columnspan": 2, "sticky": "e"}),
+            ]
+            target_row = 9
+
+        for widget, opts in placements:
+            widget.grid(**opts)
+
+        container.rowconfigure(target_row, weight=1)
+
     def _build_bulk_tab(self):
         container = ctk.CTkFrame(self.bulk_tab)
         container.pack(fill="both", expand=True, padx=12, pady=12)
+        self.bulk_container = container
 
-        help_text = (
-            "Paste tasks using this simple template (one per line):\n"
-            "Make: Write PT summary — asked by Alex — start 2025-10-06 — deadline 2025-10-08 — priority High\n"
-            "Ask: Confirm PT rules with Devs — asked by Lena\n\n"
-            "Supported keys: asked by, start, deadline, priority.\n"
-            "Dates: yyyy-mm-dd or dd.mm.yyyy; Priority: High/Medium/Low."
+        self.bulk_instruction_text = (
+            "You are the TaskFocus bulk-import assistant.\n"
+            "1. Read the notes I provide and identify every actionable task.\n"
+            "2. Decide the best Type (Make/Ask/Arrange/Control), priority, start date, and deadline."
+            " Use context or today's date when a start is missing, and leave fields blank if truly unknown.\n"
+            "3. Capture who asked for the task and the assignee whenever the information exists.\n"
+            "4. Create a short, informative Title and keep supporting details inside Description.\n\n"
+            "Return the tasks exactly in this format, one per line:\n"
+            "Type: Title — asked by <who asked> — assignee <assignee> — start <yyyy-mm-dd> — "
+            "deadline <yyyy-mm-dd> — priority <High|Medium|Low> — description <details>\n"
+            "Use yyyy-mm-dd dates (dd.mm.yyyy is also accepted on input). Title is required; omit an "
+            "optional segment entirely if the data is unavailable."
         )
-        ctk.CTkLabel(container, text=help_text, justify="left").pack(anchor="w", pady=(0,8))
+
+        instruct_frame = ctk.CTkFrame(container)
+        instruct_frame.pack(fill="x", pady=(0, 12))
+        ctk.CTkLabel(
+            instruct_frame,
+            text="Bulk import instructions for AI assistant",
+            font=("Segoe UI", 14, "bold"),
+        ).pack(anchor="w", padx=4, pady=(4, 2))
+        self.bulk_instruction_label = ctk.CTkLabel(
+            instruct_frame,
+            text=self.bulk_instruction_text,
+            justify="left",
+            wraplength=760,
+        )
+        self.bulk_instruction_label.pack(anchor="w", padx=4, pady=(0, 6))
+        ctk.CTkButton(
+            instruct_frame,
+            text="Copy instructions",
+            command=self._copy_bulk_instructions,
+            width=160,
+        ).pack(anchor="w", padx=4)
+
+        self.bulk_form_help_text = (
+            "After the AI responds, paste the generated lines below. Each line can omit optional parts, "
+            "but the parser understands the same fields as the Add Task form: Title, Type, Priority, Who asked, "
+            "Assignee, Start Date, Deadline, and Description."
+        )
+        self.bulk_form_help_label = ctk.CTkLabel(
+            container,
+            text=self.bulk_form_help_text,
+            justify="left",
+            wraplength=760,
+        )
+        self.bulk_form_help_label.pack(anchor="w", pady=(0, 8))
 
         self.bulk_text = ctk.CTkTextbox(container, height=320)
         self.bulk_text.pack(fill="both", expand=True)
@@ -585,11 +1526,239 @@ class TaskFocusApp(ctk.CTk):
         self.bulk_status.pack(side="left")
         ctk.CTkButton(btns, text="Import", command=self._bulk_import).pack(side="right")
 
+    def _refresh_stats(self):
+        if not MATPLOTLIB_AVAILABLE or not getattr(self, "stats_container", None):
+            return
+        self._render_time_spent_chart()
+        self._render_burn_chart()
+
+    def _render_time_spent_chart(self):
+        if not MATPLOTLIB_AVAILABLE or not getattr(self, "time_chart_holder", None):
+            return
+        if self.time_canvas:
+            widget = self.time_canvas.get_tk_widget()
+            widget.destroy()
+            self.time_canvas = None
+        for child in list(self.time_chart_holder.winfo_children()):
+            child.destroy()
+
+        end = date.today()
+        start = end - timedelta(days=6)
+        day_range = [start + timedelta(days=i) for i in range(7)]
+        per_task: dict[str, defaultdict[date, int]] = {}
+
+        for task in self.store.data.get("tasks", []):
+            title = task.get("title") or "(untitled)"
+            for session in task.get("sessions", []):
+                when = parse_session_timestamp(session.get("timestamp"))
+                if not when:
+                    continue
+                day = when.date()
+                if day < start or day > end:
+                    continue
+                minutes = int(session.get("minutes", 0) or 0)
+                if minutes <= 0:
+                    continue
+                bucket = per_task.setdefault(title, defaultdict(int))
+                bucket[day] += minutes
+
+        totals = {title: sum(day_map.values()) for title, day_map in per_task.items() if day_map}
+        if not totals:
+            ctk.CTkLabel(
+                self.time_chart_holder,
+                text="No session data recorded in the last 7 days.",
+                text_color="#9CA3AF",
+            ).pack(pady=24)
+            return
+
+        sorted_totals = sorted(totals.items(), key=lambda item: item[1], reverse=True)
+        top_titles = [title for title, _ in sorted_totals[:5]]
+        if len(sorted_totals) > 5:
+            other_bucket: defaultdict[date, int] = defaultdict(int)
+            for title, day_map in per_task.items():
+                if title in top_titles:
+                    continue
+                for day, minutes in day_map.items():
+                    other_bucket[day] += minutes
+            if other_bucket:
+                per_task["Other"] = other_bucket
+                top_titles.append("Other")
+
+        x = list(range(len(day_range)))
+        bottoms = [0.0] * len(day_range)
+        prop_cycle = plt.rcParams.get(
+            "axes.prop_cycle",
+            plt.cycler(color=["#8B5CF6", "#22C55E", "#F97316", "#0EA5E9", "#FACC15"]),
+        )
+        base_colors = prop_cycle.by_key().get(
+            "color", ["#8B5CF6", "#22C55E", "#F97316", "#0EA5E9", "#FACC15"]
+        )
+        color_cycle = itertools.cycle(base_colors)
+
+        fig, ax = plt.subplots(figsize=(8, 4), dpi=100)
+        for title in top_titles:
+            day_map = per_task.get(title, {})
+            values = [day_map.get(day, 0) / 60 for day in day_range]
+            color = next(color_cycle)
+            ax.bar(x, values, bottom=bottoms, label=title, color=color, edgecolor="#0F172A", linewidth=0.3)
+            bottoms = [bottoms[i] + values[i] for i in range(len(bottoms))]
+
+        ax.set_ylabel("Hours", color="#E5E7EB")
+        ax.set_xticks(x)
+        ax.set_xticklabels([day.strftime("%a %d") for day in day_range], rotation=30, ha="right", color="#E5E7EB")
+        ax.tick_params(axis="y", colors="#E5E7EB")
+        ax.grid(axis="y", color="#374151", linestyle="--", alpha=0.4)
+        ax.set_ylim(bottom=0)
+        for spine in ax.spines.values():
+            spine.set_color("#374151")
+        ax.set_facecolor("#111827")
+        fig.patch.set_facecolor("#111827")
+        legend = ax.legend(loc="upper left", bbox_to_anchor=(1.02, 1), frameon=True)
+        if legend:
+            legend.get_frame().set_facecolor("#1F2937")
+            legend.get_frame().set_edgecolor("#4B5563")
+            for text in legend.get_texts():
+                text.set_color("#F9FAFB")
+        fig.tight_layout()
+
+        self.time_canvas = FigureCanvasTkAgg(fig, master=self.time_chart_holder)
+        self.time_canvas.draw()
+        widget = self.time_canvas.get_tk_widget()
+        widget.pack(fill="both", expand=True)
+        widget.configure(background="#111827", highlightthickness=0, borderwidth=0)
+        self._time_fig = fig
+
+    def _render_burn_chart(self):
+        if not MATPLOTLIB_AVAILABLE or not getattr(self, "burn_chart_holder", None):
+            return
+        if self.burn_canvas:
+            widget = self.burn_canvas.get_tk_widget()
+            widget.destroy()
+            self.burn_canvas = None
+        for child in list(self.burn_chart_holder.winfo_children()):
+            child.destroy()
+
+        tasks = self.store.data.get("tasks", [])
+        if not tasks:
+            ctk.CTkLabel(
+                self.burn_chart_holder,
+                text="No tasks tracked yet.",
+                text_color="#9CA3AF",
+            ).pack(pady=24)
+            return
+
+        end = date.today()
+        start = end - timedelta(days=6)
+        day_range = [start + timedelta(days=i) for i in range(7)]
+
+        created_dates: list[date] = []
+        completed_dates: list[date] = []
+        today_local = date.today()
+        for task in tasks:
+            created = iso_to_date(task.get("created_at")) or today_local
+            created_dates.append(created)
+            completed = iso_to_date(task.get("completed_at")) if task.get("completed_at") else None
+            if task.get("status") == "done" and not completed:
+                completed = today_local
+            if completed:
+                completed_dates.append(completed)
+
+        remaining_counts: list[int] = []
+        completed_counts: list[int] = []
+        for day in day_range:
+            created_total = sum(1 for c in created_dates if c <= day)
+            completed_total = sum(1 for c in completed_dates if c <= day)
+            remaining_counts.append(max(created_total - completed_total, 0))
+            completed_counts.append(completed_total)
+
+        fig, ax = plt.subplots(figsize=(8, 4), dpi=100)
+        x = list(range(len(day_range)))
+        ax.plot(x, remaining_counts, marker="o", color="#38BDF8", label="Remaining tasks")
+        ax.plot(x, completed_counts, marker="o", color="#22C55E", label="Completed tasks")
+        ax.fill_between(x, remaining_counts, color="#38BDF8", alpha=0.2)
+
+        ax.set_ylabel("Tasks", color="#E5E7EB")
+        ax.set_xticks(x)
+        ax.set_xticklabels([day.strftime("%a %d") for day in day_range], rotation=30, ha="right", color="#E5E7EB")
+        ax.tick_params(axis="y", colors="#E5E7EB")
+        ax.grid(axis="y", color="#374151", linestyle="--", alpha=0.4)
+        ax.set_ylim(bottom=0)
+        for spine in ax.spines.values():
+            spine.set_color("#374151")
+        ax.set_facecolor("#111827")
+        fig.patch.set_facecolor("#111827")
+        legend = ax.legend(loc="upper left", bbox_to_anchor=(1.02, 1), frameon=True)
+        if legend:
+            legend.get_frame().set_facecolor("#1F2937")
+            legend.get_frame().set_edgecolor("#4B5563")
+            for text in legend.get_texts():
+                text.set_color("#F9FAFB")
+        fig.tight_layout()
+
+        self.burn_canvas = FigureCanvasTkAgg(fig, master=self.burn_chart_holder)
+        self.burn_canvas.draw()
+        widget = self.burn_canvas.get_tk_widget()
+        widget.pack(fill="both", expand=True)
+        widget.configure(background="#111827", highlightthickness=0, borderwidth=0)
+        self._burn_fig = fig
+
+    def _initialize_responsive_layout(self):
+        width = max(self.winfo_width(), 1)
+        self._update_responsive_layout(width)
+
+    def _on_window_configure(self, event):
+        if event.widget is not self:
+            return
+        self._pending_width = event.width
+        if self._responsive_after:
+            try:
+                self.after_cancel(self._responsive_after)
+            except Exception:
+                pass
+        self._responsive_after = self.after(120, self._commit_responsive_update)
+
+    def _commit_responsive_update(self):
+        self._responsive_after = None
+        width = self._pending_width or self.winfo_width()
+        self._update_responsive_layout(max(width, 1))
+
+    def _update_responsive_layout(self, width: int):
+        mode = "narrow" if width < 900 else "wide"
+        if mode != self._layout_mode:
+            self._layout_mode = mode
+            self._layout_add_form(mode)
+
+        self._apply_scaling(width)
+
+        wrap = max(width - 260, 360)
+        if hasattr(self, "bulk_instruction_label"):
+            self.bulk_instruction_label.configure(wraplength=wrap)
+        if hasattr(self, "bulk_form_help_label"):
+            self.bulk_form_help_label.configure(wraplength=wrap)
+
+    def _apply_scaling(self, width: int):
+        # User feedback indicated that dynamic scaling at different widths made the
+        # interface feel unstable, so keep a consistent 1.0 scale regardless of the
+        # window size.
+        scale = 1.0
+
+        if self._widget_scale == scale:
+            return
+        self._widget_scale = scale
+        ctk.set_widget_scaling(scale)
+        try:
+            ctk.set_window_scaling(scale)
+        except AttributeError:
+            # Older CustomTkinter versions do not expose set_window_scaling
+            pass
+
     # ----------------------- Actions -----------------------
     def refresh_all(self):
+        self._refresh_people_options()
         self._refresh_today_list()
         self._refresh_all_list()
         self.status_label.configure(text=f"Tasks: {len(self.store.data['tasks'])}")
+        self._refresh_stats()
 
     def _refresh_today_list(self):
         for w in self.today_list.winfo_children():
@@ -630,12 +1799,19 @@ class TaskFocusApp(ctk.CTk):
         card = TaskCard(parent, task,
                         on_edit=self._open_editor,
                         on_done_toggle=self._toggle_done,
-                        on_focus_toggle=self._toggle_focus)
+                        on_focus_toggle=self._toggle_focus,
+                        on_start_timer=self._start_task_timer,
+                        on_log_time=self._log_manual_time)
         card.pack(fill="x", padx=8, pady=8)
 
     def _toggle_done(self, task):
         new_status = "open" if task.get("status") == "done" else "done"
-        self.store.update_task(task["id"], {"status": new_status})
+        updates = {"status": new_status}
+        if new_status == "done":
+            updates["completed_at"] = datetime.now().isoformat(timespec="seconds")
+        else:
+            updates["completed_at"] = None
+        self.store.update_task(task["id"], updates)
         self.refresh_all()
 
     def _toggle_focus(self, task):
@@ -646,15 +1822,75 @@ class TaskFocusApp(ctk.CTk):
         def on_save(updated):
             self.store.update_task(task["id"], updated)
             self.refresh_all()
-        TaskEditor(self, task, on_save)
+        TaskEditor(self, task, on_save, self.store.get_people())
+
+    def _start_task_timer(self, task):
+        if self.timer_window and self.timer_window.winfo_exists():
+            messagebox.showinfo("Timer", "A timer is already running. Please finish or stop it before starting another.")
+            self.timer_window.focus()
+            return
+
+        def handle_complete(minutes):
+            self._handle_timer_completion(task.get("id"), minutes)
+
+        self.timer_window = PomodoroWindow(self, task, handle_complete, self._on_timer_closed)
+        self.timer_window.focus()
+
+    def _on_timer_closed(self):
+        self.timer_window = None
+
+    def _handle_timer_completion(self, task_id: int, minutes: int):
+        self._on_timer_closed()
+        self.bell()
+        task = next((t for t in self.store.data.get("tasks", []) if t.get("id") == task_id), None)
+        if not task:
+            messagebox.showinfo("Timer", "Task no longer exists.")
+            return
+        title = task.get("title", "Task")
+        messagebox.showinfo("Time's up!", f"{minutes} minute(s) completed for '{title}'.")
+        dialog = SessionLogDialog(
+            self,
+            title=f"Session recap — {title}",
+            preset_minutes=minutes,
+            allow_minutes_edit=True,
+            prompt="Describe what you accomplished during this focus session:",
+        )
+        result = dialog.show()
+        if result:
+            minutes_logged, note = result
+        else:
+            minutes_logged, note = minutes, ""
+        self.store.append_session(task_id, minutes_logged, note)
+        self.refresh_all()
+
+    def _log_manual_time(self, task):
+        task_id = task.get("id") if task else None
+        if not task_id:
+            return
+        title = task.get("title", "Task")
+        dialog = SessionLogDialog(
+            self,
+            title=f"Log time — {title}",
+            preset_minutes=None,
+            allow_minutes_edit=True,
+            prompt="Enter how long you worked (e.g. 90, 1:30, 1.5h) and describe what happened:",
+        )
+        result = dialog.show()
+        if not result:
+            return
+        minutes, note = result
+        self.store.append_session(task_id, minutes, note)
+        self.refresh_all()
 
     def _clear_add_form(self):
         self.add_title.delete(0, tk.END)
         self.add_type.set(TASK_TYPES[0])
         self.add_priority.set(PRIORITIES[1])
-        self.add_who.delete(0, tk.END)
+        self.add_who.set("")
+        self.add_assignee.set("")
         self.add_start.set_date(date.today())
         self.add_deadline.set_date(date.today())
+        self.add_description.delete("1.0", tk.END)
 
     def _add_task_from_form(self):
         title = self.add_title.get().strip()
@@ -666,10 +1902,12 @@ class TaskFocusApp(ctk.CTk):
             "type": self.add_type.get(),
             "priority": self.add_priority.get(),
             "who_asked": self.add_who.get().strip(),
+            "assignee": self.add_assignee.get().strip(),
             "start_date": self.add_start.get_date().strftime('%Y-%m-%d'),
             "deadline": self.add_deadline.get_date().strftime('%Y-%m-%d'),
             "status": "open",
             "focus": False,
+            "description": self.add_description.get("1.0", tk.END).strip(),
         }
         self.store.add_task(task)
         self._clear_add_form()
@@ -710,9 +1948,11 @@ class TaskFocusApp(ctk.CTk):
         info = parts[1:]
 
         who = ""
+        assignee = ""
         start_s = today_str()
         deadline_s = ""
         pr = "Medium"
+        description = ""
 
         for seg in info:
             s = seg.strip()
@@ -720,6 +1960,11 @@ class TaskFocusApp(ctk.CTk):
             m1 = re.match(r"(?i)^asked\s+by\s*:?\s*(.+)$", s)
             if m1:
                 who = m1.group(1).strip()
+                continue
+            # key: assignee / assigned to
+            m1b = re.match(r"(?i)^(assignee|assigned\s+to)\s*:?\s*(.+)$", s)
+            if m1b:
+                assignee = m1b.group(2).strip()
                 continue
             # key: start date
             m2 = re.match(r"(?i)^start\s*:?\s*(.+)$", s)
@@ -740,6 +1985,11 @@ class TaskFocusApp(ctk.CTk):
             if m4:
                 pr = m4.group(1).capitalize()
                 continue
+            # key: description / notes
+            m5 = re.match(r"(?i)^(description|desc|notes?)\s*:?\s*(.+)$", s)
+            if m5:
+                description = m5.group(2).strip()
+                continue
 
         if ttype not in TASK_TYPES:
             ttype = TASK_TYPES[0]
@@ -751,11 +2001,21 @@ class TaskFocusApp(ctk.CTk):
             "type": ttype,
             "priority": pr,
             "who_asked": who,
+            "assignee": assignee,
             "start_date": start_s,
             "deadline": deadline_s,
             "status": "open",
-            "focus": False
+            "focus": False,
+            "description": description,
         }
+
+    def _copy_bulk_instructions(self):
+        try:
+            self.clipboard_clear()
+            self.clipboard_append(self.bulk_instruction_text)
+            self.bulk_status.configure(text="Instructions copied.")
+        except Exception:
+            self.bulk_status.configure(text="Unable to copy instructions.")
 
     def _prompt_focus_selection(self):
         tasks = self.store.eligible_today()


### PR DESCRIPTION
## Summary
- replace the task card focus toggle with a compact star button and rename the timer action to "Start work" while tightening overall spacing
- centralize action button styling so the controls share a slimmer footprint, including a green "Done" state and neutral "Reopen" option when completed
- surface task descriptions and detected links directly on each card/editor with one-click open buttons and copy-enabled text areas
- collect time/session data for a new Statistics tab that charts weekly effort per task and a burn-down of remaining versus completed work
- track task completion timestamps so manual toggles feed the burn-down calculations accurately

## Testing
- python -m compileall taskfocus.py

------
https://chatgpt.com/codex/tasks/task_b_68e3d31217848322973c5b6b62b6219e